### PR TITLE
Updated react (take two) to include source files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,28 @@
         <developerConnection>scm:git:https://github.com/webjars/react.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
-    
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <source.url>https://github.com/facebook/react/archive</source.url>
         <upstream.version>0.10.0</upstream.version>
         <upstream.url>http://facebook.github.io/react/downloads</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
+        <extractDir>${project.build.directory}/react-${upstream.version}</extractDir>
+        <requirejs>
+            {
+                "paths": {
+                    "react": "react",
+                    "react-with-addons": "react-with-addons",
+                    "JSXTransformer": "JSXTransformer"
+                },
+                "shim": {
+                    "react": { "exports": "React" },
+                    "react-with-addons": { "exports": "React" },
+                    "JSXTransformer": { "exports": "transform" }
+                }
+            }
+        </requirejs>
     </properties>
 
     <build>
@@ -54,6 +70,7 @@
                 <version>1.0-beta-4</version>
                 <executions>
                     <execution>
+                        <id>download-binary</id>
                         <phase>process-resources</phase>
                         <goals>
                             <goal>download-single</goal>
@@ -62,6 +79,16 @@
                             <url>${upstream.url}</url>
                             <fromFile>react-${upstream.version}.zip</fromFile>
                             <toFile>${project.build.directory}/${project.artifactId}.zip</toFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>download-source</id>
+                        <phase>process-resources</phase>
+                        <goals><goal>download-single</goal></goals>
+                        <configuration>
+                            <url>${source.url}</url>
+                            <fromFile>v${upstream.version}.zip</fromFile>
+                            <toFile>${project.build.directory}/react-src.zip</toFile>
                         </configuration>
                     </execution>
                 </executions>
@@ -76,12 +103,28 @@
                         <goals><goal>run</goal></goals>
                         <configuration>
                             <target>
-                                <echo message="unzip archive" />
+                                <echo message="unzip binary archive" />
                                 <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}" />
                                 <echo message="moving resources" />
                                 <move todir="${destDir}">
                                     <fileset dir="${project.build.directory}/react-${upstream.version}/build" />
                                 </move>
+                                <echo message="unzip src archive" />
+                                <unzip src="${project.build.directory}/react-src.zip" dest="${project.build.directory}" />
+                                <echo message="moving resources" />
+                                <move todir="${destDir}/src">
+                                    <fileset dir="${extractDir}/src" >
+                                        <exclude name="**/__tests__/**"/>
+                                    </fileset>
+                                </move>
+                                <move todir="${destDir}/vendor">
+                                    <fileset dir="${extractDir}/vendor" />
+                                </move>
+                                <move todir="${destDir}/bin">
+                                    <fileset dir="${extractDir}/bin" />
+                                </move>
+                                <move file="${extractDir}/package.json" todir="${destDir}" />
+                                <move file="${extractDir}/main.js" todir="${destDir}" />
                             </target>
                         </configuration>
                     </execution>
@@ -92,6 +135,24 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.5</version>
+            </plugin>
+
+            <plugin>
+                <groupId>com.googlecode.todomap</groupId>
+                <artifactId>maven-jettygzip-plugin</artifactId>
+                <version>0.0.4</version>
+                <configuration>
+                    <webappDirectory>target/classes</webappDirectory>
+                    <outputDirectory>target/classes</outputDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
Include the source distribution for react (similar to what gets installed during `npm install react-tools`). I added the requirejs shim for react, react-with-addons, JSXTransformer.  I verified working requirejs shim. I also added the gz source compilation similar to the angular webjar.
