### PR TITLE
Remove gzip plugin to avoid conflict with sbt-gzip

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,24 +138,6 @@
             </plugin>
 
             <plugin>
-                <groupId>com.googlecode.todomap</groupId>
-                <artifactId>maven-jettygzip-plugin</artifactId>
-                <version>0.0.4</version>
-                <configuration>
-                    <webappDirectory>target/classes</webappDirectory>
-                    <outputDirectory>target/classes</outputDirectory>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>process</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
                 <version>1.5.1</version>


### PR DESCRIPTION
maven-jettygzip-plugin includes .gz files in the published jar so that it causes conflict when using sbt-gzip with Play framework.
